### PR TITLE
CLI component

### DIFF
--- a/action/cache.php
+++ b/action/cache.php
@@ -1,4 +1,9 @@
 <?php
+
+use dokuwiki\Extension\ActionPlugin;
+use dokuwiki\Extension\EventHandler;
+use dokuwiki\Extension\Event;
+
 /**
  * DokuWiki Plugin notification (Action Component)
  *
@@ -6,46 +11,40 @@
  * @author  Szymon Olewniczak <it@rid.pl>
  */
 
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) {
-    die();
-}
-
-class action_plugin_notification_cache extends DokuWiki_Action_Plugin
+class action_plugin_notification_cache extends ActionPlugin
 {
-
     /**
      * Registers a callback function for a given event
      *
-     * @param Doku_Event_Handler $controller DokuWiki's event controller object
+     * @param EventHandler $controller DokuWiki's event controller object
      *
      * @return void
      */
-    public function register(Doku_Event_Handler $controller)
+    public function register(EventHandler $controller)
     {
-        $controller->register_hook('PARSER_CACHE_USE', 'BEFORE', $this, 'handle_parser_cache_use');
+        $controller->register_hook('PARSER_CACHE_USE', 'BEFORE', $this, 'handleParserCacheUse');
     }
 
     /**
      *
-     * @param Doku_Event $event  event object by reference
+     * @param Event $event event object by reference
      * @param mixed      $param  [the parameters passed as fifth argument to register_hook() when this
      *                           handler was registered]
      *
      * @return void
      */
-    public function handle_parser_cache_use(Doku_Event $event, $param)
+    public function handleParserCacheUse(Event $event, $param)
     {
         /** @var cache_renderer $cache */
         $cache = $event->data;
 
-        if(!$cache->page) return;
+        if (!$cache->page) return;
         //purge only xhtml cache
-        if($cache->mode != 'xhtml') return;
+        if ($cache->mode != 'xhtml') return;
 
         //Check if it is plugins
         $notification = p_get_metadata($cache->page, 'plugin notification');
-        if(!$notification) return;
+        if (!$notification) return;
 
         if ($notification['dynamic user']) {
             $cache->_nocache = true;
@@ -57,7 +56,7 @@ class action_plugin_notification_cache extends DokuWiki_Action_Plugin
             'dependencies' => [],
             '_nocache' => false
         ];
-        trigger_event('PLUGIN_NOTIFICATION_CACHE_DEPENDENCIES', $data);
+        Event::createAndTrigger('PLUGIN_NOTIFICATION_CACHE_DEPENDENCIES', $data);
 
         //add a media directories to dependencies
         $cache->depends['files'] = array_merge($cache->depends['files'], $data['dependencies']);

--- a/action/cron.php
+++ b/action/cron.php
@@ -44,96 +44,30 @@ class action_plugin_notification_cron extends DokuWiki_Action_Plugin
         $cron_helper = plugin_load('helper', 'notification_cron');
         $cron_helper->addUsersToCron();
 
-
         //get the oldest check
         $res = $sqlite->query('SELECT user, MIN(timestamp) FROM cron_check');
         $user = $sqlite->res2single($res);
-        //no user to sent notifications
+        //no user to send notifications to
         if (!$user) return;
 
         //update user last check
         $sqlite->query('UPDATE cron_check SET timestamp=? WHERE user=?',  date('c'), $user);
 
-        $plugins = [];
-        trigger_event('PLUGIN_NOTIFICATION_REGISTER_SOURCE', $plugins);
-        $notifications_data = [
-            'plugins' => $plugins,
-            'user' => $user,
-            'notifications' => []
-        ];
-        trigger_event('PLUGIN_NOTIFICATION_GATHER', $notifications_data);
+        // get new notifications from plugins
+        $notification_data = $cron_helper->getNotificationData($user);
 
-        $notifications = $notifications_data['notifications'];
-        //no notifications - nothing to sent
-        if (!$notifications) return;
+        //no notifications - nothing to send
+        if (empty($notification_data['notifications'])) return;
 
-        //get only notifications that has id
-        $notifications = array_filter($notifications, function ($notification) {
-            return array_key_exists('id', $notification);
-        });
-        //no notifications - nothing to sent
-        if (!$notifications) return;
+        $new_notifications = $cron_helper->getNewNotifications($user, $notification_data);
 
-        //get the notifications that has been sent already
-        $res = $sqlite->query('SELECT plugin, notification_id FROM notification WHERE user=?', $user);
-        $sent_notifications = $sqlite->res2arr($res);
-        $sent_notifications_by_plugin = [];
-        foreach ($plugins as $plugin) {
-            $sent_notifications_by_plugin[$plugin] = [];
-        }
-        foreach ($sent_notifications as $sent_notification) {
-            $plugin = $sent_notification['plugin'];
-            $id = $sent_notification['notification_id'];
-            $sent_notifications_by_plugin[$plugin][$id] = true;
-        }
-
-        $new_notifications = [];
-        foreach ($notifications as $notification) {
-            $plugin = $notification['plugin'];
-            $id = $notification['id'];
-            if (!isset($sent_notifications_by_plugin[$plugin][$id])) {
-                $new_notifications[] = $notification;
-            }
-        }
-
-        //no notifications - nothing to sent
+        // no notifications left - nothing to send
         if (!$new_notifications) return;
 
-        $html = '<p>' . $this->getLang('mail content');
-        $html .= '<ul>';
-        $text = $this->getLang('mail content') . "\n\n";
-
-        usort($new_notifications, function($a, $b) {
-            if ($a['timestamp'] == $b['timestamp']) {
-                return 0;
-            }
-            return ($a['timestamp'] > $b['timestamp']) ? -1 : 1;
-        });
-
-        foreach ($new_notifications as $notification) {
-            $content = $notification['full'];
-            $timestamp = $notification['timestamp'];
-
-            $date = strftime('%d.%m %H:%M', $timestamp);
-
-            $html .= "<li class=\"level1\"><div class=\"li\">$date $content</div></li>";
-            $text .= $date . ' ' . strip_tags($content). "\n";
-        }
-        $html .= '</ul></p>';
-
-        $mail = new Mailer();
-        $userinfo = $auth->getUserData($user, $requireGroups = false);
-        $mail->to($userinfo['name'].' <'.$userinfo['mail'].'>');
-        $mail->subject($this->getLang('mail subject'));
-        $mail->setBody($text, null, null, $html);
-        $mail->send();
-
-        //mark notifications as sent
-        foreach ($new_notifications as $notification) {
-            $plugin = $notification['plugin'];
-            $id = $notification['id'];
-            $sqlite->storeEntry('notification',
-                ['plugin' => $plugin, 'notification_id' => $id, 'user' => $user, 'sent' => date('c')]);
+        list($text, $html) = $cron_helper->composeEmail($new_notifications);
+        if ($cron_helper->sendMail($user, $text, $html)) {
+            //mark notifications as sent
+            $cron_helper->storeSentNotifications($user, $new_notifications);
         }
 
         $event->stopPropagation();

--- a/action/cron.php
+++ b/action/cron.php
@@ -1,36 +1,38 @@
 <?php
 
+use dokuwiki\Extension\ActionPlugin;
+use dokuwiki\Extension\EventHandler;
+use dokuwiki\Extension\Event;
+
 /**
  * DokuWiki Plugin notification (Action Component)
  *
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  * @author  Szymon Olewniczak <it@rid.pl>
  */
-
-class action_plugin_notification_cron extends DokuWiki_Action_Plugin
+class action_plugin_notification_cron extends ActionPlugin
 {
-
     /**
      * Registers a callback function for a given event
      *
-     * @param Doku_Event_Handler $controller DokuWiki's event controller object
+     * @param EventHandler $controller DokuWiki's event controller object
      *
      * @return void
      */
-    public function register(Doku_Event_Handler $controller)
+    public function register(EventHandler $controller)
     {
-        $controller->register_hook('INDEXER_TASKS_RUN', 'AFTER', $this, 'handle_indexer_tasks_run');
+        $controller->register_hook('INDEXER_TASKS_RUN', 'AFTER', $this, 'handleIndexerTasksRun');
     }
 
     /**
      *
-     * @param Doku_Event $event  event object by reference
+     * @param Event $event event object by reference
      * @param mixed      $param  [the parameters passed as fifth argument to register_hook() when this
      *                           handler was registered]
      *
      * @return void
      */
-    public function handle_indexer_tasks_run(Doku_Event $event, $param)
+    public function handleIndexerTasksRun(Event $event, $param)
     {
         /** @var DokuWiki_Auth_Plugin $auth */
         global $auth;
@@ -51,7 +53,7 @@ class action_plugin_notification_cron extends DokuWiki_Action_Plugin
         if (!$user) return;
 
         //update user last check
-        $sqlite->query('UPDATE cron_check SET timestamp=? WHERE user=?',  date('c'), $user);
+        $sqlite->query('UPDATE cron_check SET timestamp=? WHERE user=?', date('c'), $user);
 
         // get new notifications from plugins
         $notification_data = $cron_helper->getNotificationData($user);

--- a/action/cron.php
+++ b/action/cron.php
@@ -7,11 +7,6 @@
  * @author  Szymon Olewniczak <it@rid.pl>
  */
 
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) {
-    die();
-}
-
 class action_plugin_notification_cron extends DokuWiki_Action_Plugin
 {
 

--- a/action/migration.php
+++ b/action/migration.php
@@ -1,35 +1,31 @@
 <?php
-/**
- * DokuWiki Plugin bez (Action Component)
- *
- */
 
-// must be run within Dokuwiki
-
-if (!defined('DOKU_INC')) die();
+use dokuwiki\Extension\ActionPlugin;
+use dokuwiki\Extension\EventHandler;
+use dokuwiki\Extension\Event;
 
 /**
- * Class action_plugin_bez_migration
+ * Class action_plugin_notification_migration
  *
  * Handle migrations that need more than just SQL
  */
-class action_plugin_notification_migration extends DokuWiki_Action_Plugin
+class action_plugin_notification_migration extends ActionPlugin
 {
     /**
      * @inheritDoc
      */
-    public function register(Doku_Event_Handler $controller)
+    public function register(EventHandler $controller)
     {
-        $controller->register_hook('PLUGIN_SQLITE_DATABASE_UPGRADE', 'AFTER', $this, 'handle_migrations');
+        $controller->register_hook('PLUGIN_SQLITE_DATABASE_UPGRADE', 'AFTER', $this, 'handleMigrations');
     }
 
     /**
      * Call our custom migrations when defined
      *
-     * @param Doku_Event $event
+     * @param Event $event
      * @param $param
      */
-    public function handle_migrations(Doku_Event $event, $param)
+    public function handleMigrations(Event $event, $param)
     {
         if ($event->data['sqlite']->getAdapter()->getDbname() !== 'notification') {
             return;
@@ -50,8 +46,10 @@ class action_plugin_notification_migration extends DokuWiki_Action_Plugin
         $sqlite = $db_helper->getDB();
 
         foreach (array_keys($auth->retrieveUsers()) as $user) {
-            $sqlite->storeEntry('cron_check',
-                ['user' => $user, 'timestamp' => date('c', 0)]);
+            $sqlite->storeEntry(
+                'cron_check',
+                ['user' => $user, 'timestamp' => date('c', 0)]
+            );
         }
     }
 }

--- a/cli.php
+++ b/cli.php
@@ -1,0 +1,104 @@
+<?php
+
+use splitbrain\phpcli\Options;
+
+class cli_plugin_notification extends DokuWiki_CLI_Plugin
+{
+    /** @var helper_plugin_notification_db */
+    protected $db_helper;
+
+    /** @var helper_plugin_notification_cron */
+    protected $cron_helper;
+
+    /**
+     * Initialize helper plugin
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->db_helper = plugin_load('helper', 'notification_db');
+        $this->cron_helper = plugin_load('helper', 'notification_cron');
+    }
+
+    /**
+     * Register options and arguments on the given $options object
+     *
+     * @param Options $options
+     * @return void
+     * @throws \splitbrain\phpcli\Exception
+     */
+    protected function setup(Options $options)
+    {
+        $options->setHelp('Bulk notification dispatcher');
+        $options->registerCommand('send', 'Send all due notifications');
+    }
+
+    /**
+     * Your main program
+     *
+     * Arguments and options have been parsed when this is run
+     *
+     * @param Options $options
+     * @return void
+     */
+    protected function main(Options $options)
+    {
+        $cmd = $options->getCmd();
+        switch ($cmd) {
+            case 'send':
+                $this->sendNotifications();
+                break;
+            default:
+                $this->error('No command provided');
+                exit(1);
+        }
+    }
+
+    /**
+     * Check and send notifications
+     */
+    protected function sendNotifications()
+    {
+        $sqlite = $this->db_helper->getDB();
+
+        // get users from DB
+        $sql = 'SELECT user FROM cron_check';
+        $result = $sqlite->query($sql);
+        $rows = $sqlite->res2arr($result);
+        if (!is_array($rows)) {
+            $this->info('Exiting: no users to notify found.');
+            return;
+        }
+        // gather new notifications per user
+        foreach ($rows as $row) {
+            $user = $row['user'];
+
+            // update timestamp of cron check
+            $sqlite->query('UPDATE cron_check SET timestamp=? WHERE user=?',  date('c'), $user);
+
+            $notification_data = $this->cron_helper->getNotificationData($user);
+
+            //no notifications - nothing to send
+            if (empty($notification_data['notifications'])) {
+                $this->info('No notifications at all for user ' . $user);
+                continue;
+            }
+
+            $new_notifications = $this->cron_helper->getNewNotifications($user, $notification_data);
+            //  send email
+            // no notifications left - nothing to send
+            if (!$new_notifications) {
+                $this->info('No new notifications for user ' . $user);
+                continue;
+            }
+
+            list($text, $html) = $this->cron_helper->composeEmail($new_notifications);
+            if ($this->cron_helper->sendMail($user, $text, $html)) {
+                $this->cron_helper->storeSentNotifications($user, $new_notifications);
+                $this->info('Sent notification to ' . $user);
+            } else {
+                $this->error('Failed sending notification to ' . $user);
+            }
+        }
+    }
+}

--- a/cli.php
+++ b/cli.php
@@ -1,8 +1,10 @@
 <?php
 
+use dokuwiki\Extension\CLIPlugin;
+use splitbrain\phpcli\Exception;
 use splitbrain\phpcli\Options;
 
-class cli_plugin_notification extends DokuWiki_CLI_Plugin
+class cli_plugin_notification extends CLIPlugin
 {
     /** @var helper_plugin_notification_db */
     protected $db_helper;
@@ -25,7 +27,7 @@ class cli_plugin_notification extends DokuWiki_CLI_Plugin
      *
      * @param Options $options
      * @return void
-     * @throws \splitbrain\phpcli\Exception
+     * @throws Exception
      */
     protected function setup(Options $options)
     {
@@ -74,7 +76,7 @@ class cli_plugin_notification extends DokuWiki_CLI_Plugin
             $user = $row['user'];
 
             // update timestamp of cron check
-            $sqlite->query('UPDATE cron_check SET timestamp=? WHERE user=?',  date('c'), $user);
+            $sqlite->query('UPDATE cron_check SET timestamp=? WHERE user=?', date('c'), $user);
 
             $notification_data = $this->cron_helper->getNotificationData($user);
 

--- a/helper/cron.php
+++ b/helper/cron.php
@@ -176,7 +176,6 @@ class helper_plugin_notification_cron extends DokuWiki_Plugin
      */
     public function storeSentNotifications($user, $notifications)
     {
-        // FIXME refactor
         /** @var \helper_plugin_notification_db $db_helper */
         $db_helper = plugin_load('helper', 'notification_db');
         $sqlite = $db_helper->getDB();

--- a/helper/cron.php
+++ b/helper/cron.php
@@ -40,4 +40,152 @@ class helper_plugin_notification_cron extends DokuWiki_Plugin
                 ['user' => $user, 'timestamp' => date('c', 0)]);
         }
     }
+
+    /**
+     * Gather notification data from plugins
+     *
+     * @param string $user
+     * @return array
+     */
+    public function getNotificationData($user)
+    {
+        $plugins = [];
+        $event = new Doku_Event('PLUGIN_NOTIFICATION_REGISTER_SOURCE', $plugins);
+        $event->trigger();
+        $notifications_data = [
+            'plugins' => $plugins,
+            'user' => $user,
+            'notifications' => []
+        ];
+        $event = new Doku_Event('PLUGIN_NOTIFICATION_GATHER', $notifications_data);
+        $event->trigger();
+
+        if (!empty($notifications_data['notifications'])) {
+            $notifications = $notifications_data['notifications'];
+
+            // get only notifications that have ids
+            $notifications_data['notifications'] = array_filter($notifications, function ($notification) {
+                return array_key_exists('id', $notification);
+            });
+        }
+
+        return $notifications_data;
+    }
+
+    /**
+     * Prune old (already sent) notifications and return only new ones
+     *
+     * @param string $user
+     * @param array $notification_data
+     * @return array
+     */
+    public function getNewNotifications($user, $notification_data)
+    {
+        /** @var \helper_plugin_notification_db $db_helper */
+        $db_helper = plugin_load('helper', 'notification_db');
+        $sqlite = $db_helper->getDB();
+
+        $notifications = $notification_data['notifications'];
+        $plugins = $notification_data['plugins'];
+
+        //get the notifications that have been sent already
+        $res = $sqlite->query('SELECT plugin, notification_id FROM notification WHERE user=?', $user);
+        $sent_notifications = $sqlite->res2arr($res);
+        $sent_notifications_by_plugin = [];
+        foreach ($plugins as $plugin) {
+            $sent_notifications_by_plugin[$plugin] = [];
+        }
+        foreach ($sent_notifications as $sent_notification) {
+            $plugin = $sent_notification['plugin'];
+            $id = $sent_notification['notification_id'];
+            $sent_notifications_by_plugin[$plugin][$id] = true;
+        }
+
+        // keep only notifications not yet sent
+        $new_notifications = [];
+        foreach ($notifications as $notification) {
+            $plugin = $notification['plugin'];
+            $id = $notification['id'];
+            if (!isset($sent_notifications_by_plugin[$plugin][$id])) {
+                $new_notifications[] = $notification;
+            }
+        }
+
+        return $new_notifications;
+    }
+
+    /**
+     * Create text and HTML components of email message
+     *
+     * @param array $new_notifications
+     * @return string[]
+     */
+    public function composeEmail($new_notifications)
+    {
+        $html = '<p>' . $this->getLang('mail content') . '</p>';
+        $html .= '<ul>';
+        $text = $this->getLang('mail content') . "\n\n";
+
+        usort($new_notifications, function($a, $b) {
+            if ($a['timestamp'] == $b['timestamp']) {
+                return 0;
+            }
+            return ($a['timestamp'] > $b['timestamp']) ? -1 : 1;
+        });
+
+        foreach ($new_notifications as $notification) {
+            $content = $notification['full'];
+            $timestamp = $notification['timestamp'];
+
+            $date = strftime('%d.%m %H:%M', $timestamp);
+
+            $html .= "<li class=\"level1\"><div class=\"li\">$date $content</div></li>";
+            $text .= $date . ' ' . strip_tags($content). "\n";
+        }
+        $html .= '</ul>';
+
+        return [$text, $html];
+    }
+
+    /**
+     * Send notification email to the given user
+     *
+     * @param string $user
+     * @param string $text
+     * @param string $html
+     * @return bool true if email was sent successfully
+     */
+    public function sendMail($user, $text, $html)
+    {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+
+        $mail = new Mailer();
+        $userinfo = $auth->getUserData($user, false);
+        $mail->to($userinfo['name'].' <'.$userinfo['mail'].'>');
+        $mail->subject($this->getLang('mail subject'));
+        $mail->setBody($text, null, null, $html);
+        return $mail->send();
+    }
+
+    /**
+     * Store info about sent notifications
+     *
+     * @param string $user
+     * @param array $notifications
+     */
+    public function storeSentNotifications($user, $notifications)
+    {
+        // FIXME refactor
+        /** @var \helper_plugin_notification_db $db_helper */
+        $db_helper = plugin_load('helper', 'notification_db');
+        $sqlite = $db_helper->getDB();
+
+        foreach ($notifications as $notification) {
+            $plugin = $notification['plugin'];
+            $id = $notification['id'];
+            $sqlite->storeEntry('notification',
+                ['plugin' => $plugin, 'notification_id' => $id, 'user' => $user, 'sent' => date('c')]);
+        }
+    }
 }

--- a/helper/db.php
+++ b/helper/db.php
@@ -1,13 +1,14 @@
 <?php
 
+use dokuwiki\Extension\Plugin;
+
 /**
  * DokuWiki Plugin notification (Helper Component)
  *
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  * @author  Szymon Olewniczak <dokuwiki@cosmocode.de>
  */
-
-class helper_plugin_notification_db extends DokuWiki_Plugin
+class helper_plugin_notification_db extends Plugin
 {
     /** @var helper_plugin_sqlite */
     protected $sqlite;
@@ -27,7 +28,6 @@ class helper_plugin_notification_db extends DokuWiki_Plugin
      */
     protected function init()
     {
-        /** @var helper_plugin_sqlite $sqlite */
         $this->sqlite = plugin_load('helper', 'sqlite');
         if (!$this->sqlite) {
             if (defined('DOKU_UNITTEST')) {

--- a/helper/db.php
+++ b/helper/db.php
@@ -1,16 +1,11 @@
 <?php
+
 /**
- * DokuWiki Plugin watchcycle (Helper Component)
+ * DokuWiki Plugin notification (Helper Component)
  *
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  * @author  Szymon Olewniczak <dokuwiki@cosmocode.de>
  */
-
-// must be run within Dokuwiki
-
-if (!defined('DOKU_INC')) {
-    die();
-}
 
 class helper_plugin_notification_db extends DokuWiki_Plugin
 {
@@ -76,25 +71,4 @@ class helper_plugin_notification_db extends DokuWiki_Plugin
         }
         return $this->sqlite;
     }
-
-    /**
-     * Completely remove the database and reinitialize it
-     *
-     * You do not want to call this except for testing!
-     */
-    public function resetDB()
-    {
-        if (!$this->sqlite) {
-            return;
-        }
-        $file = $this->sqlite->getAdapter()->getDbFile();
-        if (!$file) {
-            return;
-        }
-        unlink($file);
-        clearstatcache(true, $file);
-        $this->init();
-    }
 }
-
-// vim:ts=4:sw=4:et:


### PR DESCRIPTION
The new CLI component can be used to send mails in the background, for example per system cron. This is especially useful for seldom visited wikis, where the usual notification triggers are not happening often enough to ensure timely notifications.

The PR includes:
- some refactoring to make the relevant code available to CLI component
- CLI component itself
- code style fixes, mostly automatic (by dev plugin) with minor manual touch-ups